### PR TITLE
Add 8BitDo Pro 2 to gamepad support matrix

### DIFF
--- a/docs/GamepadSupportMatrix.md
+++ b/docs/GamepadSupportMatrix.md
@@ -26,4 +26,5 @@ The FIRST Driver Station uses SDL for gamepad support. Most common gamepads work
 | Steam Controller 2026 | `28DE:1106` | ✅ | ❌ | ✅ | ✅ | Does not enumerate on macOS |
 | REV USB PS4 Compatible |  | ⚠️ | ✅ | ✅ | ❌ | Shows up as a generic Xbox controller on Windows, missing much of the functionality. |
 | Logitech F310 |  | ✅ | ✅ | ✅ | ❌ | Must be in D mode to show up correctly on macOS. |
+| 8BitDo Pro 2 |  | ✅ | ✅ | ✅ | ⚠️ | Back buttons are supported in D mode with latest firmware. No SN in XInput mode. |
 | PowerA Advantage Switch 2 | `20D6:A720` | ⚠️ | ⚠️ | ⚠️ | ❌ | Shows up as a joystick without gamepad mappings. |


### PR DESCRIPTION
The [8BitDo Pro 2](https://www.8bitdo.com/pro2/) has 4 different connection modes:

- Switch
- Apple (legacy DS4 emulation, not recommended)
- D-Input (recommended)
- XInput

Strictly speaking (as documented on [8BitDo's Steam compatibility page](https://www.8bitdo.com/steam/)) firmware v3.06 or newer is required for full features and known correct mapping, including the back buttons. macOS also won't enumerate this gamepad in XInput mode.